### PR TITLE
fix: notices PHP sur les actions de prolongement et de résiliation

### DIFF
--- a/action/prolonger_abonnement.php
+++ b/action/prolonger_abonnement.php
@@ -22,7 +22,10 @@ function action_prolonger_abonnement_dist($arg = null) {
 		$arg = $securiser_action();
 	}
 
-	list($id_abonnement, $nb, $unite) = explode('-', $arg);
+	$composants_arg = array_filter(explode('-', $arg));
+	$id_abonnement = (int) ($composants_arg[0] ?? 0);
+	$nb = $composants_arg[1] ?? null;
+	$unite = $composants_arg[2] ?? null;
 
 	include_spip('inc/autoriser');
 	if (

--- a/action/resilier_abonnement.php
+++ b/action/resilier_abonnement.php
@@ -26,7 +26,8 @@ function action_resilier_abonnement_dist($arg = null) {
 	$resilier = charger_fonction('resilier', 'abos');
 	$raison = (test_espace_prive() ? 'resil BO par admin' : 'resil par client');
 	if ($id_abonnement = intval($arg)) {
-		list(, $immediat) = explode('-', $arg);
+		$composants_arg = array_filter(explode('-', $arg));
+		$immediat = $composants_arg[1] ?? null;
 		$immediat = ($immediat == 'echeance') ? false : true;
 	} elseif (
 		substr($arg, 0, 3) == 'uid'


### PR DESCRIPTION
Exemple de notice : `Warning: Undefined array key 1`