### PR TITLE
fix: unsupported operand si prix_ht vide

### DIFF
--- a/prix/abooffre.php
+++ b/prix/abooffre.php
@@ -6,7 +6,7 @@ if (!defined('_ECRIRE_INC_VERSION')) {
 }
 
 function prix_abooffre_dist($id_objet, $prix_ht) {
-	$prix = $prix_ht;
+	$prix = (float) $prix_ht;
 
 	$abos_taux_tva = charger_fonction('abos_taux_tva', 'inc');
 	$taxe = $abos_taux_tva(0, $id_objet);


### PR DESCRIPTION
Si jamais une offre a les 2 champs prix HT vides, on se retrouve avec une string vide en valeur, le taux est un float, et ça provoque une erreur.

Patch rapide, mais il faudrait revoir l'implémentation de l'API de prix sur ce plugin.

fixes: #15